### PR TITLE
makuosan多重実行時に発生する不具合対応

### DIFF
--- a/makuo.py
+++ b/makuo.py
@@ -135,11 +135,12 @@ class Makuo(object):
         result = self.do_command(b'status')
         status = {}
         for L in result.splitlines():
-            if L.count(b':') == 1:
-                k, v = L.split(b':')
-                k = k.strip()
-                v = v.strip()
-                status[k] = v
+            if b':' not in L:
+                continue
+            k, v = L.split(b':', 1)
+            k = k.strip()
+            v = v.strip()
+            status[k] = v
         return status
 
     def close(self):

--- a/makuo.py
+++ b/makuo.py
@@ -135,10 +135,11 @@ class Makuo(object):
         result = self.do_command(b'status')
         status = {}
         for L in result.splitlines():
-            k, v = L.split(b':')
-            k = k.strip()
-            v = v.strip()
-            status[k] = v
+            if L.count(b':') == 1:
+                k, v = L.split(b':')
+                k = k.strip()
+                v = v.strip()
+                status[k] = v
         return status
 
     def close(self):


### PR DESCRIPTION
## 目的

makuosan多重実行時に発生する不具合対応
## 経緯

makuosanを多重実行した場合、statusのレスポンスが一部予期しないフォーマットとなり、エラーが発生する
## 対応

statueのレスポンスフォーマットが `○:○` 以外の場合、無視するように修正

@methane 
